### PR TITLE
tests download before replacing existing binary

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -172,12 +172,24 @@ try {
     # --- install ---
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
     $destination = Join-Path $InstallDir $Bin
-    Copy-Item -Path $binaryPath -Destination $destination -Force
 
-    # Verify binary executes.
-    & $destination --version *> $null
+    # Verify the new binary executes BEFORE replacing any existing install.
+    & $binaryPath --version *> $null
     if ($LASTEXITCODE -ne 0) {
-        Fail "installed binary failed to execute" "this may indicate a platform mismatch or a corrupted download"
+        Fail "downloaded binary failed to execute" `
+             "existing installation (if any) has not been modified" `
+             "this may indicate a platform mismatch or a corrupted download"
+    }
+
+    # Atomic replacement: stage in install dir (same volume), then rename.
+    # File.Replace uses the Windows ReplaceFile API for atomic swap.
+    # For fresh installs (no existing binary), Move-Item is sufficient.
+    $stagingPath = "$destination.tmp"
+    Copy-Item -Path $binaryPath -Destination $stagingPath -Force
+    if (Test-Path $destination) {
+        [System.IO.File]::Replace($stagingPath, $destination, $null)
+    } else {
+        Move-Item -Path $stagingPath -Destination $destination -Force
     }
 
     # GitHub Actions support.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -125,13 +125,20 @@ main() {
     fi
 
     mkdir -p "$install_dir"
-    # Atomic install with permissions (no cp+chmod race).
-    install -m 755 "${tmp_dir}/${binary_name}" "${install_dir}/${BIN}"
 
-    if ! "${install_dir}/${BIN}" --version >/dev/null 2>&1; then
-        error "installed binary failed to execute" \
+    # Verify the new binary executes BEFORE replacing any existing install.
+    chmod +x "${tmp_dir}/${binary_name}"
+    if ! "${tmp_dir}/${binary_name}" --version >/dev/null 2>&1; then
+        error "downloaded binary failed to execute" \
+              "existing installation (if any) has not been modified" \
               "this may indicate a platform mismatch or a corrupted download"
     fi
+
+    # Atomic replacement: stage in install dir (same filesystem), then rename.
+    # mv on the same filesystem is an atomic rename — the old binary is either
+    # fully present or fully replaced, never partially written.
+    install -m 755 "${tmp_dir}/${binary_name}" "${install_dir}/${BIN}.tmp"
+    mv -f "${install_dir}/${BIN}.tmp" "${install_dir}/${BIN}"
 
     # GitHub Actions: add to $GITHUB_PATH so subsequent steps find bx.
     if [ -n "${GITHUB_ACTIONS:-}" ] && [ -n "${GITHUB_PATH:-}" ]; then


### PR DESCRIPTION
Make sure we don't replace any existing copy of bx until we have verified the newly downloaded version works as expected.