### PR TITLE
feat/npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -127,15 +127,16 @@ jobs:
             flags+=(--provenance) # signed build attestation; needs id-token: write
           fi
 
-          # Publish one package directory, skipping it when that exact version
-          # is already on npm. Versions are immutable, so this makes the job
-          # safely re-runnable after a partial failure.
+          # Publish one package directory, skipping it when that exact version is
+          # already on npm. Versions are immutable, so this makes the job safely
+          # re-runnable after a partial failure. Dry runs never skip, otherwise
+          # they would validate nothing for an already-published version.
           publish() {
             local dir="$1" name version
             name=$(jq -r .name "$dir/package.json")
             version=$(jq -r .version "$dir/package.json")
 
-            if npm view "$name@$version" version >/dev/null 2>&1; then
+            if [ "$DRY_RUN" != "true" ] && npm view "$name@$version" version >/dev/null 2>&1; then
               echo "skip $name@$version (already published)"
               return
             fi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,6 +30,8 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Only the binaries come from the release tag; the npm package files come
+      # from the dispatched ref (tags up to v1.5.0 predate npm/).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -64,48 +66,39 @@ jobs:
           tmp=$(mktemp -d)
 
           stage() {
-            local release_asset="$1" npm_platform="$2" bin_name="$3"
-            local asset="bx-${VERSION}-${release_asset}"
-            [ "$bin_name" = "bx.exe" ] && asset="${asset}.exe"
+            local target="$1" npm_platform="$2" ext=""
+            case "$target" in windows-*) ext=".exe" ;; esac
+            local asset="bx-${VERSION}-${target}${ext}"
 
-            # Download the binary alongside its checksum, then verify integrity
-            # before we trust it enough to publish to npm.
-            gh release download "$TAG" --dir "$tmp" --clobber \
+            # Catches a corrupt or truncated download, not tampering: the
+            # checksum ships in the same release as the binary.
+            gh release download "$TAG" --dir "$tmp" \
               --pattern "$asset" --pattern "$asset.sha256"
+            (cd "$tmp" && sha256sum -c "$asset.sha256")
 
-            local expected actual
-            expected=$(cut -d' ' -f1 < "$tmp/$asset.sha256")
-            actual=$(sha256sum "$tmp/$asset" | cut -d' ' -f1)
-            if [ "$expected" != "$actual" ]; then
-              echo "::error::checksum mismatch for $asset (expected $expected, got $actual)"
-              exit 1
-            fi
-
-            mkdir -p "npm/platforms/${npm_platform}/bin"
-            cp "$tmp/$asset" "npm/platforms/${npm_platform}/bin/${bin_name}"
-            chmod +x "npm/platforms/${npm_platform}/bin/${bin_name}"
+            # Platform packages declare no "bin", so npm never chmods them on
+            # install — the executable bit has to ship in the tarball.
+            install -Dm755 "$tmp/$asset" "npm/platforms/${npm_platform}/bin/bx${ext}"
           }
 
-          stage linux-amd64   linux-x64    bx
-          stage linux-arm64   linux-arm64  bx
-          stage darwin-arm64  darwin-arm64 bx
-          stage windows-amd64 win32-x64    bx.exe
-          stage windows-arm64 win32-arm64  bx.exe
+          stage linux-amd64   linux-x64
+          stage linux-arm64   linux-arm64
+          stage darwin-arm64  darwin-arm64
+          stage windows-amd64 win32-x64
+          stage windows-arm64 win32-arm64
 
-      - name: Stage license into packages
-        run: |
-          set -euo pipefail
-          # npm ships a LICENSE file automatically when one is present, so drop
-          # the repository license into every package we publish.
-          for dir in npm/platforms/*/ npm/brave-search-cli/; do
-            cp LICENSE "$dir"
-          done
+          # Proves the exec bit survived staging and the asset matches the tag.
+          npm/platforms/linux-x64/bin/bx --version | grep -qF "$VERSION"
 
-      - name: Set package versions
+      - name: Stage license and versions into packages
         env:
           VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
+          # npm ships a LICENSE file automatically when one is present.
+          for dir in npm/platforms/*/ npm/brave-search-cli/; do
+            cp LICENSE "$dir"
+          done
 
           for dir in npm/platforms/*/; do
             jq --arg v "$VERSION" '.version = $v' "${dir}package.json" > "${dir}package.json.tmp"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,9 +32,11 @@ jobs:
 
       - name: Resolve release
         id: release
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          tag="${{ inputs.version }}"
+          tag="$INPUT_VERSION"
           if [ -z "$tag" ]; then
             tag=$(gh release view --json tagName -q .tagName)
           fi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -40,34 +40,33 @@ jobs:
         run: |
           set -euo pipefail
           tag="$INPUT_VERSION"
-          if [ -z "$tag" ]; then
-            tag=$(gh release view --json tagName -q .tagName)
-          fi
-          gh release view "$tag" >/dev/null
+          [ -n "$tag" ] || tag=$(gh release view --json tagName -q .tagName)
 
-          case "$tag" in
-            v[0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "::error::unexpected tag format: $tag"; exit 1 ;;
-          esac
+          # Anchored: the tag reaches later steps as a shell variable, and a
+          # pre-release would otherwise claim npm's "latest" dist-tag.
+          [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+            { echo "::error::unexpected tag format: $tag"; exit 1; }
+          gh release view "$tag" >/dev/null
 
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
       - name: Download and stage platform binaries
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
-          version="${{ steps.release.outputs.version }}"
-          tag="${{ steps.release.outputs.tag }}"
           tmp=$(mktemp -d)
 
           stage() {
             local release_asset="$1" npm_platform="$2" bin_name="$3"
-            local asset="bx-${version}-${release_asset}"
+            local asset="bx-${VERSION}-${release_asset}"
             [ "$bin_name" = "bx.exe" ] && asset="${asset}.exe"
 
             # Download the binary alongside its checksum, then verify integrity
             # before we trust it enough to publish to npm.
-            gh release download "$tag" --dir "$tmp" --clobber \
+            gh release download "$TAG" --dir "$tmp" --clobber \
               --pattern "$asset" --pattern "$asset.sha256"
 
             local expected actual
@@ -99,16 +98,17 @@ jobs:
           done
 
       - name: Set package versions
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
-          version="${{ steps.release.outputs.version }}"
 
           for dir in npm/platforms/*/; do
-            jq --arg v "$version" '.version = $v' "${dir}package.json" > "${dir}package.json.tmp"
+            jq --arg v "$VERSION" '.version = $v' "${dir}package.json" > "${dir}package.json.tmp"
             mv "${dir}package.json.tmp" "${dir}package.json"
           done
 
-          jq --arg v "$version" \
+          jq --arg v "$VERSION" \
              '.version = $v | .optionalDependencies |= with_entries(.value = $v)' \
              npm/brave-search-cli/package.json > npm/brave-search-cli/package.json.tmp
           mv npm/brave-search-cli/package.json.tmp npm/brave-search-cli/package.json

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,114 @@
+name: Publish npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to publish (e.g. v1.5.0). Leave blank to use the latest release."
+        required: false
+        type: string
+      dry_run:
+        description: "Run npm publish with --dry-run (packs and validates everything, publishes nothing)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Resolve release
+        id: release
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.version }}"
+          if [ -z "$tag" ]; then
+            tag=$(gh release view --json tagName -q .tagName)
+          fi
+          gh release view "$tag" >/dev/null
+
+          case "$tag" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "::error::unexpected tag format: $tag"; exit 1 ;;
+          esac
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download and stage platform binaries
+        run: |
+          set -euo pipefail
+          version="${{ steps.release.outputs.version }}"
+          tag="${{ steps.release.outputs.tag }}"
+          tmp=$(mktemp -d)
+
+          stage() {
+            local release_asset="$1" npm_platform="$2" bin_name="$3"
+            local asset="bx-${version}-${release_asset}"
+            [ "$bin_name" = "bx.exe" ] && asset="${asset}.exe"
+
+            gh release download "$tag" --dir "$tmp" --clobber --pattern "$asset"
+
+            mkdir -p "npm/platforms/${npm_platform}/bin"
+            cp "$tmp/$asset" "npm/platforms/${npm_platform}/bin/${bin_name}"
+            chmod +x "npm/platforms/${npm_platform}/bin/${bin_name}"
+          }
+
+          stage linux-amd64   linux-x64    bx
+          stage linux-arm64   linux-arm64  bx
+          stage darwin-arm64  darwin-arm64 bx
+          stage windows-amd64 win32-x64    bx.exe
+          stage windows-arm64 win32-arm64  bx.exe
+
+      - name: Set package versions
+        run: |
+          set -euo pipefail
+          version="${{ steps.release.outputs.version }}"
+
+          for dir in npm/platforms/*/; do
+            jq --arg v "$version" '.version = $v' "${dir}package.json" > "${dir}package.json.tmp"
+            mv "${dir}package.json.tmp" "${dir}package.json"
+          done
+
+          jq --arg v "$version" \
+             '.version = $v | .optionalDependencies |= with_entries(.value = $v)' \
+             npm/brave-search-cli/package.json > npm/brave-search-cli/package.json.tmp
+          mv npm/brave-search-cli/package.json.tmp npm/brave-search-cli/package.json
+
+      - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          flags=(--no-git-checks --access public)
+          [ "$DRY_RUN" = "true" ] && flags+=(--dry-run)
+          for dir in npm/platforms/*/; do
+            (cd "$dir" && npm publish "${flags[@]}")
+          done
+
+      # Published last so its optionalDependencies always resolve to
+      # already-published platform package versions.
+      - name: Publish main package
+        working-directory: npm/brave-search-cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          flags=(--no-git-checks --access public)
+          [ "$DRY_RUN" = "true" ] && flags+=(--dry-run)
+          npm publish "${flags[@]}"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,6 +20,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: npm-publish
+    permissions:
+      contents: read # gh release download
+      id-token: write # npm provenance attestation
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -101,27 +104,38 @@ jobs:
              npm/brave-search-cli/package.json > npm/brave-search-cli/package.json.tmp
           mv npm/brave-search-cli/package.json.tmp npm/brave-search-cli/package.json
 
-      - name: Publish platform packages
+      - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          flags=(--no-git-checks --access public)
-          [ "$DRY_RUN" = "true" ] && flags+=(--dry-run)
-          for dir in npm/platforms/*/; do
-            (cd "$dir" && npm publish "${flags[@]}")
-          done
 
-      # Published last so its optionalDependencies always resolve to
-      # already-published platform package versions.
-      - name: Publish main package
-        working-directory: npm/brave-search-cli
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -euo pipefail
           flags=(--no-git-checks --access public)
-          [ "$DRY_RUN" = "true" ] && flags+=(--dry-run)
-          npm publish "${flags[@]}"
+          if [ "$DRY_RUN" = "true" ]; then
+            flags+=(--dry-run)
+          else
+            flags+=(--provenance) # signed build attestation; needs id-token: write
+          fi
+
+          # Publish one package directory, skipping it when that exact version
+          # is already on npm. Versions are immutable, so this makes the job
+          # safely re-runnable after a partial failure.
+          publish() {
+            local dir="$1" name version
+            name=$(jq -r .name "$dir/package.json")
+            version=$(jq -r .version "$dir/package.json")
+
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "skip $name@$version (already published)"
+              return
+            fi
+            (cd "$dir" && npm publish "${flags[@]}")
+          }
+
+          # Platform packages first: the main package pins their exact versions
+          # in optionalDependencies, so they must already exist when it publishes.
+          for dir in npm/platforms/*/; do
+            publish "${dir%/}"
+          done
+          publish npm/brave-search-cli

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -89,6 +89,15 @@ jobs:
           stage windows-amd64 win32-x64    bx.exe
           stage windows-arm64 win32-arm64  bx.exe
 
+      - name: Stage license into packages
+        run: |
+          set -euo pipefail
+          # npm ships a LICENSE file automatically when one is present, so drop
+          # the repository license into every package we publish.
+          for dir in npm/platforms/*/ npm/brave-search-cli/; do
+            cp LICENSE "$dir"
+          done
+
       - name: Set package versions
         run: |
           set -euo pipefail

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -120,7 +124,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          flags=(--no-git-checks --access public)
+          flags=(--access public)
           if [ "$DRY_RUN" = "true" ]; then
             flags+=(--dry-run)
           else

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -62,7 +62,18 @@ jobs:
             local asset="bx-${version}-${release_asset}"
             [ "$bin_name" = "bx.exe" ] && asset="${asset}.exe"
 
-            gh release download "$tag" --dir "$tmp" --clobber --pattern "$asset"
+            # Download the binary alongside its checksum, then verify integrity
+            # before we trust it enough to publish to npm.
+            gh release download "$tag" --dir "$tmp" --clobber \
+              --pattern "$asset" --pattern "$asset.sha256"
+
+            local expected actual
+            expected=$(cut -d' ' -f1 < "$tmp/$asset.sha256")
+            actual=$(sha256sum "$tmp/$asset" | cut -d' ' -f1)
+            if [ "$expected" != "$actual" ]; then
+              echo "::error::checksum mismatch for $asset (expected $expected, got $actual)"
+              exit 1
+            fi
 
             mkdir -p "npm/platforms/${npm_platform}/bin"
             cp "$tmp/$asset" "npm/platforms/${npm_platform}/bin/${bin_name}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /dist/
 /.cargo/
 /npm/platforms/*/bin/
+# LICENSE files are copied into each package at publish time (see publish-npm.yml).
+/npm/platforms/*/LICENSE
+/npm/brave-search-cli/LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /dist/
 /.cargo/
+/npm/platforms/*/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 /target/
 /dist/
 /.cargo/
+# Staged into each npm package at publish time (see publish-npm.yml).
 /npm/platforms/*/bin/
-# LICENSE files are copied into each package at publish time (see publish-npm.yml).
 /npm/platforms/*/LICENSE
 /npm/brave-search-cli/LICENSE
+
+node_modules/
+*.tgz

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ cat request.json | bx answers -
 | 3 | Auth/permission error (401/403) | Check API key or plan: `bx config show-key` |
 | 4 | Rate limited (429) | Retry after delay |
 | 5 | Server/network error | Retry with backoff |
-| 127 | npm launcher could not find the binary | Reinstall, or check platform support |
+| 127 | npm launcher could not start bx | Reinstall, or check platform support |
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ cat request.json | bx answers -
 | 3 | Auth/permission error (401/403) | Check API key or plan: `bx config show-key` |
 | 4 | Rate limited (429) | Retry after delay |
 | 5 | Server/network error | Retry with backoff |
+| 127 | npm launcher could not find the binary | Reinstall, or check platform support |
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ curl -fsSL https://raw.githubusercontent.com/brave/brave-search-cli/main/scripts
 powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/brave/brave-search-cli/main/scripts/install.ps1 | iex"
 ```
 
+**npm**
+```bash
+npm install -g @brave/brave-search-cli
+```
+
 ```bash
 bx config set-key YOUR_API_KEY    # get a key at https://api-dashboard.search.brave.com
 bx "your search query"            # shorthand for: bx context "your search query"

--- a/npm/brave-search-cli/README.md
+++ b/npm/brave-search-cli/README.md
@@ -1,0 +1,13 @@
+# @brave/brave-search-cli
+
+`bx` — a token-efficient CLI for the [Brave Search API](https://brave.com/search/api/), built for AI agents and LLMs.
+
+```bash
+npm install -g @brave/brave-search-cli
+bx config set-key YOUR_API_KEY
+bx "your search query"
+```
+
+This package installs the prebuilt `bx` binary for your platform (via optional dependencies — no build step, no postinstall download). Supported platforms: macOS (arm64), Linux (x64, arm64), Windows (x64, arm64).
+
+Full documentation: https://github.com/brave/brave-search-cli

--- a/npm/brave-search-cli/bin/bx.js
+++ b/npm/brave-search-cli/bin/bx.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+'use strict'
+
+const { spawnSync } = require('node:child_process')
+
+const PLATFORM_PACKAGES = {
+  'darwin arm64': '@brave/brave-search-cli-darwin-arm64',
+  'linux x64': '@brave/brave-search-cli-linux-x64',
+  'linux arm64': '@brave/brave-search-cli-linux-arm64',
+  'win32 x64': '@brave/brave-search-cli-win32-x64',
+  'win32 arm64': '@brave/brave-search-cli-win32-arm64',
+}
+
+function fail(message) {
+  console.error(`bx: ${message}`)
+  process.exit(1)
+}
+
+const key = `${process.platform} ${process.arch}`
+const pkg = PLATFORM_PACKAGES[key]
+
+if (!pkg) {
+  fail(
+    `unsupported platform (${key}). ` +
+      'See https://github.com/brave/brave-search-cli#quick-start for other install options.'
+  )
+}
+
+const binName = process.platform === 'win32' ? 'bx.exe' : 'bx'
+
+let binPath
+try {
+  binPath = require.resolve(`${pkg}/bin/${binName}`)
+} catch {
+  fail(
+    `the optional dependency "${pkg}" did not install. ` +
+      'Try reinstalling, or install directly: https://github.com/brave/brave-search-cli#quick-start'
+  )
+}
+
+const result = spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit' })
+
+if (result.error) {
+  fail(`failed to run "${binPath}": ${result.error.message}`)
+}
+
+process.exit(result.status === null ? 1 : result.status)

--- a/npm/brave-search-cli/bin/bx.js
+++ b/npm/brave-search-cli/bin/bx.js
@@ -46,11 +46,10 @@ if (result.error) {
   fail(`failed to run "${binPath}": ${result.error.message}`)
 }
 
-// If bx was killed by a signal, exit with the shell's 128 + signal convention;
-// otherwise pass through its exit code.
+// Killed by a signal: use the shell's 128 + N convention.
 if (result.signal) {
   const signalNumber = signals[result.signal]
   process.exit(signalNumber ? 128 + signalNumber : 1)
 }
 
-process.exit(result.status === null ? 1 : result.status)
+process.exit(result.status ?? 1)

--- a/npm/brave-search-cli/bin/bx.js
+++ b/npm/brave-search-cli/bin/bx.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const { spawnSync } = require('node:child_process')
+const { signals } = require('node:os').constants
 
 const PLATFORM_PACKAGES = {
   'darwin arm64': '@brave/brave-search-cli-darwin-arm64',
@@ -42,6 +43,13 @@ const result = spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit' })
 
 if (result.error) {
   fail(`failed to run "${binPath}": ${result.error.message}`)
+}
+
+// If bx was killed by a signal, exit with the shell's 128 + signal convention;
+// otherwise pass through its exit code.
+if (result.signal) {
+  const signalNumber = signals[result.signal]
+  process.exit(signalNumber ? 128 + signalNumber : 1)
 }
 
 process.exit(result.status === null ? 1 : result.status)

--- a/npm/brave-search-cli/bin/bx.js
+++ b/npm/brave-search-cli/bin/bx.js
@@ -12,9 +12,10 @@ const PLATFORM_PACKAGES = {
   'win32 arm64': '@brave/brave-search-cli-win32-arm64',
 }
 
+// 127 ("command not found") keeps launch failures out of bx's own 0-5 range.
 function fail(message) {
   console.error(`bx: ${message}`)
-  process.exit(1)
+  process.exit(127)
 }
 
 const key = `${process.platform} ${process.arch}`

--- a/npm/brave-search-cli/package.json
+++ b/npm/brave-search-cli/package.json
@@ -22,6 +22,9 @@
   "files": [
     "bin"
   ],
+  "engines": {
+    "node": ">=16"
+  },
   "optionalDependencies": {
     "@brave/brave-search-cli-darwin-arm64": "0.0.0",
     "@brave/brave-search-cli-linux-x64": "0.0.0",

--- a/npm/brave-search-cli/package.json
+++ b/npm/brave-search-cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@brave/brave-search-cli",
+  "version": "0.0.0",
+  "description": "A token-efficient CLI for the Brave Search API, built for AI agents and LLMs",
+  "homepage": "https://github.com/brave/brave-search-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brave/brave-search-cli.git"
+  },
+  "bugs": "https://github.com/brave/brave-search-cli/issues",
+  "license": "MPL-2.0",
+  "keywords": [
+    "brave",
+    "search",
+    "cli",
+    "rag",
+    "llm"
+  ],
+  "bin": {
+    "bx": "bin/bx.js"
+  },
+  "files": [
+    "bin"
+  ],
+  "optionalDependencies": {
+    "@brave/brave-search-cli-darwin-arm64": "0.0.0",
+    "@brave/brave-search-cli-linux-x64": "0.0.0",
+    "@brave/brave-search-cli-linux-arm64": "0.0.0",
+    "@brave/brave-search-cli-win32-x64": "0.0.0",
+    "@brave/brave-search-cli-win32-arm64": "0.0.0"
+  }
+}

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -16,5 +16,6 @@
   ],
   "files": [
     "bin"
-  ]
+  ],
+  "preferUnplugged": true
 }

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@brave/brave-search-cli-darwin-arm64",
+  "version": "0.0.0",
+  "description": "darwin-arm64 binary for @brave/brave-search-cli",
+  "homepage": "https://github.com/brave/brave-search-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brave/brave-search-cli.git"
+  },
+  "license": "MPL-2.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin"
+  ]
+}

--- a/npm/platforms/linux-arm64/package.json
+++ b/npm/platforms/linux-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@brave/brave-search-cli-linux-arm64",
+  "version": "0.0.0",
+  "description": "linux-arm64 binary for @brave/brave-search-cli",
+  "homepage": "https://github.com/brave/brave-search-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brave/brave-search-cli.git"
+  },
+  "license": "MPL-2.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin"
+  ]
+}

--- a/npm/platforms/linux-arm64/package.json
+++ b/npm/platforms/linux-arm64/package.json
@@ -16,5 +16,6 @@
   ],
   "files": [
     "bin"
-  ]
+  ],
+  "preferUnplugged": true
 }

--- a/npm/platforms/linux-x64/package.json
+++ b/npm/platforms/linux-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@brave/brave-search-cli-linux-x64",
+  "version": "0.0.0",
+  "description": "linux-x64 binary for @brave/brave-search-cli",
+  "homepage": "https://github.com/brave/brave-search-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brave/brave-search-cli.git"
+  },
+  "license": "MPL-2.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ]
+}

--- a/npm/platforms/linux-x64/package.json
+++ b/npm/platforms/linux-x64/package.json
@@ -16,5 +16,6 @@
   ],
   "files": [
     "bin"
-  ]
+  ],
+  "preferUnplugged": true
 }

--- a/npm/platforms/win32-arm64/package.json
+++ b/npm/platforms/win32-arm64/package.json
@@ -16,5 +16,6 @@
   ],
   "files": [
     "bin"
-  ]
+  ],
+  "preferUnplugged": true
 }

--- a/npm/platforms/win32-arm64/package.json
+++ b/npm/platforms/win32-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@brave/brave-search-cli-win32-arm64",
+  "version": "0.0.0",
+  "description": "win32-arm64 binary for @brave/brave-search-cli",
+  "homepage": "https://github.com/brave/brave-search-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brave/brave-search-cli.git"
+  },
+  "license": "MPL-2.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin"
+  ]
+}

--- a/npm/platforms/win32-x64/package.json
+++ b/npm/platforms/win32-x64/package.json
@@ -16,5 +16,6 @@
   ],
   "files": [
     "bin"
-  ]
+  ],
+  "preferUnplugged": true
 }

--- a/npm/platforms/win32-x64/package.json
+++ b/npm/platforms/win32-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@brave/brave-search-cli-win32-x64",
+  "version": "0.0.0",
+  "description": "win32-x64 binary for @brave/brave-search-cli",
+  "homepage": "https://github.com/brave/brave-search-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brave/brave-search-cli.git"
+  },
+  "license": "MPL-2.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ]
+}


### PR DESCRIPTION
Support for `--dry_run` added to test workflow in non-destructive manner, without side effects.